### PR TITLE
Enable npm minimum release age via security preset

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,7 +5,8 @@
     ":timezone(Asia/Tokyo)",
     ":prHourlyLimitNone",
     ":automergePatch",
-    ":automergeDigest"
+    ":automergeDigest",
+    "security:minimumReleaseAgeNpm"
   ],
   "labels": ["Dependencies", "renovate"],
   "vulnerabilityAlerts": {


### PR DESCRIPTION
## 背景

kanade0404/agegis の CI で `pnpm install --frozen-lockfile` が `ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION` で失敗しました（[PR #308](https://github.com/kanade0404/agegis/pull/308)、Renovate による oxfmt 0.61.0 → 0.64.0 の更新）。

原因は pnpm 11 のデフォルト supply-chain policy `minimumReleaseAge`（既定 1440 分 = 24 時間）に、対象パッケージ（oxfmt 0.64.0）が抵触したことです。Renovate が npm publish のわずか約 3 時間後に更新 PR を作成しており、pnpm 側の release-age チェックを通過できませんでした。

agegis の `renovate.json` は `local>kanade0404/renovate-config` の共有 config を extends しているだけで、この共有 config 側には `minimumReleaseAge` / `stabilityDays` 相当の設定が未導入でした。

## なぜこの config に入れるか

この問題は pnpm 11 の `minimumReleaseAge` policy と Renovate の組み合わせに起因するもので、特定リポジトリ固有の事情ではありません。共有 config (`kanade0404/renovate-config`) に設定を入れることで、この preset を参照する全リポジトリで同様の CI 失敗を未然に防げます。

## 何をするか

`extends` 配列の末尾に公式プリセット [`security:minimumReleaseAgeNpm`](https://docs.renovatebot.com/presets-security/) を追加します。

このプリセットは:
- npm datasource のみを対象にする
- `minimumReleaseAge: "3 days"` を設定する
- `internalChecksFilter: "strict"` により、release age の条件を満たすまで Renovate 自身が PR 作成を遅延させる

`lockFileMaintenance` / `pin` / `replacement` の各更新種別はこのプリセットの対象から除外されます。

## 既知の残存ギャップ

`lockFileMaintenance` による更新は仕様上 `minimumReleaseAge` の対象外です。そのため、この更新経路では今回と同様の CI 失敗が稀に再発する可能性があります。

## 参考リンク

- https://docs.renovatebot.com/presets-security/
- https://github.com/kanade0404/agegis/pull/308

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/kanade0404/renovate-config/pull/1856" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Renovateによる依存関係のダイジェスト更新を自動マージできるようになりました。
  * npm依存関係の更新に、最低リリース待機期間を設定しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->